### PR TITLE
fix white on white in darkmode

### DIFF
--- a/src/app/form/autocomplete/autocomplete.component.scss
+++ b/src/app/form/autocomplete/autocomplete.component.scss
@@ -1,6 +1,5 @@
 .autocomplete-list {
-    background-color: rgb(247, 244, 244);
-    margin-bottom: -8px;
+    margin-bottom: 10px;
 }
 ion-icon {
     float: right;
@@ -9,11 +8,7 @@ ion-icon {
 ion-list {
     padding-top: 0;
 }
-ion-item {
-    --background:rgb(247, 244, 244);
-}
 .value-list {
     width: 98%;
-    background-color: rgb(247, 244, 244);
 }
 

--- a/src/app/form/autocomplete/autocomplete.component.scss
+++ b/src/app/form/autocomplete/autocomplete.component.scss
@@ -1,5 +1,5 @@
 .autocomplete-list {
-    margin-bottom: 10px;
+    margin-bottom: -8px;
 }
 ion-icon {
     float: right;


### PR DESCRIPTION
If somebody uses dark mode, the autocomplete on place in add flight is white on white: 

![image](https://user-images.githubusercontent.com/7059532/107975427-612df700-6fb8-11eb-9f8a-bfd49951baa5.png)

suggestion: 

light mode:
![image](https://user-images.githubusercontent.com/7059532/107975693-c97cd880-6fb8-11eb-93b6-995f997b7fd9.png)


dark mode:
![image](https://user-images.githubusercontent.com/7059532/107975570-976b7680-6fb8-11eb-81af-0fd120c63d34.png)

